### PR TITLE
Fix highlights in employments

### DIFF
--- a/src/components/employment.tsx
+++ b/src/components/employment.tsx
@@ -8,8 +8,9 @@ const Employment = ({employment}: {employment: IEmployment}) => {
                 <h3>{employment.position} - {employment.company}<br/>{employment.location}<br/>{employment.startDate} → {employment.endDate}</h3>
             </Box>
             <Box>
+                {employment.summary} 
                 <ul>
-                <li> {employment.summary} </li>
+                {employment.highlights.map(highlight => <li> {highlight} </li>)}
                 </ul>
             </Box>
         </Box>


### PR DESCRIPTION
I noticed that highlights are not shown in the rendered CV which i think is pitty. Also with the fact that I would like to have text under employment in bullet list