### PR TITLE
Fixes crash on invalid YAML and adds recursive check that all properties are set

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-ace": "^10.1.0",
     "react-dom": "^18.2.0",
+    "react-error-boundary": "^4.0.11",
     "react-html-parser": "^2.0.2",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.3",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
-import React, {useEffect, useMemo, useState} from 'react';
+import React, {ReactElement, useEffect, useMemo, useState} from 'react';
+import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
 import './App.css';
 import Page from "./components/page";
 import Divider from "./components/divider";
@@ -24,7 +25,7 @@ interface IProjectPart extends IProject {
   part: number;
 }
 
-function App() {
+const App = () => {
     const [, setMD] = useState<string>("");
     const [data, setData] = useState<IResume>(testData);
     const [showYaml, setShowYaml] = useState<boolean>(false);
@@ -78,7 +79,6 @@ function App() {
     const yamlChange = (newData: any)=> {
         setData({...newData});
     }
-
     return (
         <div style={{
             display: 'flex',
@@ -99,7 +99,26 @@ function App() {
                 height: '100vh',
                 overflowX: 'auto'
             }}>
-                <div id="printableDiv">
+                {createPage(data, projects)}
+            </div>
+        </div>
+    );
+}
+const ErrorFallback = () => {
+  const { resetBoundary } = useErrorBoundary();
+
+  return (
+    <div role="alert" id="printableDiv" style={{padding: "10mm"}}>
+      <p>Something went wrong! Check console for errors.</p>
+      <button onClick={resetBoundary}>Try again</button>
+    </div>
+  );
+}
+
+const createPage = (data: IResume, projects: (IProjectPart[])[]) => {
+    return (
+        <div id="printableDiv">
+            <ErrorBoundary FallbackComponent={ErrorFallback}>
                 <Page>
                     <Summary summary={data.summary} educationHeading={data.educationHeading}/>
                     {data.skillSet && <><Divider title={data.skillSetHeading || 'Skillset'}/>
@@ -125,16 +144,16 @@ function App() {
                 )}
                 {
                     data.employments?.length > 0 && (
-                        <><Page>
-                    <Divider title={data.employmentsHeading || 'Employments'} marginTop='0mm'/>
-                    {data.employments.map(employment => <Employment employment={employment}/>)}
-                </Page></>
+                        <>
+                            <Page>
+                                <Divider title={data.employmentsHeading || 'Employments'} marginTop='0mm'/>
+                                {data.employments.map(employment => <Employment employment={employment}/>)}
+                            </Page>
+                        </>
                     )
-                }
-                </div>
-            </div>
+                };
+            </ErrorBoundary>
         </div>
-    );
+    )
 }
-
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,7 +10,7 @@ import ProjectResponsibilities from "./components/project-responsibilities";
 import Employment from "./components/employment";
 import {marked} from 'marked';
 import example from "./Example.md";
-import { testData } from './sample';
+import { validationData } from './validation';
 import { IResume, IProject } from './interfaces/resume.interface';
 import YAMLEditor from './components/yaml-editor/YamlEditor';
 import InfoEditor from './components/info-editor/InfoEditor';
@@ -27,7 +27,7 @@ interface IProjectPart extends IProject {
 
 const App = () => {
     const [, setMD] = useState<string>("");
-    const [data, setData] = useState<IResume>(testData);
+    const [data, setData] = useState<IResume>(validationData);
     const [showYaml, setShowYaml] = useState<boolean>(false);
     const projects = useMemo(() => {
         const formattedProjects: (IProjectPart[])[] = [];

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, {ReactElement, useEffect, useMemo, useState} from 'react';
+import { useEffect, useMemo, useState} from 'react';
 import { ErrorBoundary, useErrorBoundary } from "react-error-boundary";
 import './App.css';
 import Page from "./components/page";

--- a/src/components/yaml-editor/YamlEditor.tsx
+++ b/src/components/yaml-editor/YamlEditor.tsx
@@ -21,16 +21,36 @@ const YAMLEditor: React.FC<any> = ({ initialJSON, yamlChange }: any) => {
     }
   };
 
+  const checkContainsKeys = (input: any, validationInput: any, searchKey: string) => {
+    // If input type is a string, number, etc (not a object), skip it
+    if (typeof(validationInput) !== "object")
+      return
+    Object.keys(validationInput)
+        // Each of these keys should exist in the input
+        .map(key => {
+          // If property in input is a list, each element must be checked
+          if (Array.isArray(input[key])) {
+            input[key].forEach( (subInput: any, index: number) =>
+              checkContainsKeys(subInput, validationInput[key][0], `${key}-${index}`)
+            )
+          // Recursively check properties in property(object) of key
+          } else if (typeof(input[key]) === "object") {
+            checkContainsKeys(input[key], validationInput[key], key)
+          }
+          return key
+        })
+        .filter(key => typeof(input[key]) === "undefined")
+        .forEach(key => {
+          throw new Error(`Propery "${searchKey}" is missing: "${key}"`)
+        });
+  }
+
   const handleEditorChange = (newYamlText: string) => {
     setYamlText(newYamlText);
     try {
       const newJsonData = yaml.load(newYamlText);
       if (newJsonData && typeof newJsonData === 'object') {
-        const newKeys = Object.keys(newJsonData);
-
-        if (!newKeys.every((key) => originalKeys.includes(key))) {
-          throw new Error("Keys cannot be edited!");
-        }
+        checkContainsKeys(newJsonData, validationData, "root level")
         setError(null);
         yamlChange(newJsonData);
       } else {

--- a/src/components/yaml-editor/YamlEditor.tsx
+++ b/src/components/yaml-editor/YamlEditor.tsx
@@ -41,7 +41,7 @@ const YAMLEditor: React.FC<any> = ({ initialJSON, yamlChange }: any) => {
         })
         .filter(key => typeof(input[key]) === "undefined")
         .forEach(key => {
-          throw new Error(`Propery "${searchKey}" is missing: "${key}"`)
+          throw new Error(`Property "${searchKey}" is missing: "${key}"`)
         });
   }
 

--- a/src/components/yaml-editor/YamlEditor.tsx
+++ b/src/components/yaml-editor/YamlEditor.tsx
@@ -1,14 +1,12 @@
 import React, { useState } from "react";
 import AceEditor from "react-ace";
+import { validationData } from '../../validation';
 import "ace-builds/src-noconflict/mode-yaml";
 import "ace-builds/src-noconflict/theme-github";
 import yaml from "js-yaml";
 
-
-
 const YAMLEditor: React.FC<any> = ({ initialJSON, yamlChange }: any) => {
   const [yamlText, setYamlText] = useState<string>(yaml.dump(initialJSON));
-  const [originalKeys, ] = useState<string[]>(Object.keys(initialJSON));
   const [error, setError] = useState<string | null>(null);
 
   const handleFileUpload = (event: any) => {

--- a/src/interfaces/resume.interface.ts
+++ b/src/interfaces/resume.interface.ts
@@ -1,9 +1,9 @@
 export interface IResume {
-    certificationsHeading?: string;
-    skillSetHeading?: string;
-    educationHeading?: string;
-    employmentsHeading?: string;
-    projectsHeading?: string;
+    certificationsHeading: string;
+    skillSetHeading: string;
+    educationHeading: string;
+    employmentsHeading: string;
+    projectsHeading: string;
     summary:     ISummary;
     employments: IEmployment[];
     education:   IEducation[];
@@ -22,10 +22,10 @@ export interface ISummary {
 
 export interface ICertificate {
     name: string;
-      link?: string;
-      organizationName?: string;
-      linkDisplayText?: string;
-      certificateId?:string;
+    link: string;
+    organizationName: string;
+    linkDisplayText: string;
+    certificateId:string;
 }
 
 export interface ILocation {
@@ -64,11 +64,11 @@ export interface IEmployment {
 }
 
 export interface IProject {
-    startPageBreak?:  boolean;
-    middlePageBreak?: boolean;
+    startPageBreak:   boolean;
+    middlePageBreak:  boolean;
     name:             string;
     company:          string;
-    companyLogoUrl?:  string;
+    companyLogoUrl:   string;
     startDate:        string;
     endDate:          string;
     description:      string;

--- a/src/validation.ts
+++ b/src/validation.ts
@@ -1,11 +1,11 @@
 import { IResume } from "./interfaces/resume.interface";
 
-export const testData: IResume = {
-  certificationsHeading: 'Certification',
-  educationHeading: 'Education',
-  employmentsHeading: 'Employments',
-  projectsHeading: 'Projects',
-  skillSetHeading: 'Skillset',
+export const validationData: IResume = {
+  certificationsHeading: '',
+  educationHeading: '',
+  employmentsHeading: '',
+  projectsHeading: '',
+  skillSetHeading: '',
   "summary": {
     name: "Moatter",
     title: "Digial designer",
@@ -135,10 +135,10 @@ operation and integrations
   certifications: [
     {
       name: 'Test',
-      link: 'Link',
-      linkDisplayText: 'Link text',
-      organizationName: 'Hello',
-      certificateId: 'Test'
+      link: '',
+      linkDisplayText: '',
+      organizationName: '',
+      certificateId: ''
     }
   ]
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -8144,6 +8144,13 @@ react-dom@^18.2.0:
     loose-envify "^1.1.0"
     scheduler "^0.23.0"
 
+react-error-boundary@^4.0.11:
+  version "4.0.11"
+  resolved "https://registry.yarnpkg.com/react-error-boundary/-/react-error-boundary-4.0.11.tgz#36bf44de7746714725a814630282fee83a7c9a1c"
+  integrity sha512-U13ul67aP5DOSPNSCWQ/eO0AQEYzEFkVljULQIjMV0KlffTAhxuDoBKdO0pb/JZ8mDhMKFZ9NZi0BmLGUiNphw==
+  dependencies:
+    "@babel/runtime" "^7.12.5"
+
 react-error-overlay@^6.0.11:
   version "6.0.11"
   resolved "https://registry.yarnpkg.com/react-error-overlay/-/react-error-overlay-6.0.11.tgz#92835de5841c5cf08ba00ddd2d677b6d17ff9adb"


### PR DESCRIPTION

![image](https://github.com/stakater/resume-renderer/assets/6649265/577705ea-b120-406f-b4bf-7b15a447bc4d)
![image](https://github.com/stakater/resume-renderer/assets/6649265/c3afd57b-546f-4d9d-8cca-4b649227932e)


If the check somehow fails, I also added an error boundary so that you can keep editing the yaml even though it crashes and burns:fire:

![image](https://github.com/stakater/resume-renderer/assets/6649265/629695a3-719f-4dec-b710-db7e9ce89d91)


I also made all properties required and ok to be empty to remove the need for users to go look for which properties exists.
